### PR TITLE
adding rakefile and gem for testing of links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,8 @@ The information below is for maintainers of this blog (members of the team coop-
 - [Reviewing and publishing blog posts](#reviewing-and-publishing)
 - [Tags](#tags)
 - [Formatting and layout](#formatting-and-layout)
+- [Check for broken links](#checking-for-broken-links)
+- [Referencing a Fred Hutch username](referencing-a-fred-hutch-username)
 
 ### Reviewing and publishing
 
@@ -113,3 +115,15 @@ tags: # here we have added tags to R and python to the blog post
 - Additional modifications for the blog theme are from:
   - [Bioinformatics Interest Group (FHBig)](https://fredhutch.github.io/FHBig/)
   - [Fred Hutch Biomedical Data Science Wiki](https://sciwiki.fredhutch.org)
+
+### Checking for broken links
+To check for broken links, you can type `rake test`. This will exit with an error if there are any broken links, and list the broken links and the files they are found in.
+
+If you are inside the Fred Hutch network, you can type `rake testlocal` and that will include internal URLs in the check.
+
+### Referencing a Fred Hutch username
+Please if you need to reference a Fred Hutch username, do not write the entire email address out, just put the username in backticks like this:
+
+```
+`username`
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,8 @@ If you would prefer to not be listed on our contributors page, you should encase
 The information below is for maintainers of this blog (members of the team coop-blog-maintainers). This includes:
 - [Reviewing and publishing blog posts](#reviewing-and-publishing)
 - [Tags](#tags)
-- [Formatting and layout](#formatting-and-layout)
-- [Check for broken links](#checking-for-broken-links)
-- [Referencing a Fred Hutch username](referencing-a-fred-hutch-username)
+- [Formatting and style](#formatting-and-style)
+- [Rendering and layout](#rendering-and-layout)
 
 ### Reviewing and publishing
 
@@ -103,27 +102,53 @@ tags: # here we have added tags to R and python to the blog post
    - python
  ```
 
-### Formatting and layout
+### Formatting and style
 
-- This blog renders from the `gh-pages` branch.
-- The template for the blog is [Minimal Mistakes Jekyll theme](https://github.com/mmistakes/minimal-mistakes). The following links and language were included in the original README and are copied here for convenience:
+- Please do not include entire email addresses in a post. If you would like to include contact information for a Fred Hutch email, please put the username in backticks like this:
+
+```
+`username`
+```
+
+### Rendering and layout
+
+- The template for the blog is [Minimal Mistakes Jekyll theme](https://github.com/mmistakes/minimal-mistakes). Additional modifications for the blog theme are from:
+  - [Bioinformatics Interest Group (FHBig)](https://fredhutch.github.io/FHBig/)
+  - [Fred Hutch Biomedical Data Science Wiki](https://sciwiki.fredhutch.org)
+- General information on Minimal Mistakes rendering was included in the template's README and are copied here for convenience:
   - Please see [this page](https://mmistakes.github.io/minimal-mistakes/docs/configuration/) for additional information on configuration.
   - If you have a question about using Jekyll, start a discussion on the [Jekyll Forum](https://talk.jekyllrb.com/) or [StackOverflow](https://stackoverflow.com/questions/tagged/jekyll).
   - [Ruby 101](https://jekyllrb.com/docs/ruby-101/)
   - [Setting up a Jekyll site with GitHub Pages](https://jekyllrb.com/docs/github-pages/)
   - [Configuring GitHub Metadata](https://github.com/jekyll/github-metadata/blob/master/docs/configuration.md#configuration) to work properly when developing locally and avoid `No GitHub API authentication could be found. Some fields may be missing or have incorrect data.` warnings.
-- Additional modifications for the blog theme are from:
-  - [Bioinformatics Interest Group (FHBig)](https://fredhutch.github.io/FHBig/)
-  - [Fred Hutch Biomedical Data Science Wiki](https://sciwiki.fredhutch.org)
+- This blog renders from the `gh-pages` branch.
 
-### Checking for broken links
-To check for broken links, you can type `rake test`. This will exit with an error if there are any broken links, and list the broken links and the files they are found in.
+#### Building the site locally
+
+You may want to build a copy of this wiki locally (on your own computer) to make sure that it looks the way you want before pushing your changes.
+
+1. Clone the repo locally
+1. Install Ruby (version 1.9.2 or later).
+**Note**: most modern Mac computers already have Ruby installed. If you still need Ruby,
+it can be found [here](https://www.ruby-lang.org/en/downloads/).
+1. On Mac, install xcode commandline tools `xcode-select --install`
+
+1. You may need to install `bundler`. Type
+   `which bundler` to see if it is already
+   installed. If nothing is returned, then
+   install `bundler` with `gem install bundler`.
+   If that fails, try `sudo gem install bundler`.
+   
+1. You may need to install gems used by the site.
+   Type `gem install -g Gemfile` to install all of the gems the site uses.
+
+1. To build and view the site locally, from the cloned repo directory run
+   `bundle install` then run `bundle exec jekyll serve`. Once the
+   site is built you can view it at
+   [http://localhost:4000](http://localhost:4000).
+
+#### Checking for broken links
+
+To check for broken links, run `rake test` on your clone of the repository. This will exit with an error if there are any broken links, and list the broken links and the files they are found in.
 
 If you are inside the Fred Hutch network, you can type `rake testlocal` and that will include internal URLs in the check.
-
-### Referencing a Fred Hutch username
-Please if you need to reference a Fred Hutch username, do not write the entire email address out, just put the username in backticks like this:
-
-```
-`username`
-```

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-algolia"
+  gem 'html-proofer'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,27 @@
+require 'html-proofer'
+
+task :test do
+  sh "bundle exec jekyll build"
+  options = { :assume_extension => true,
+    :empty_alt_ignore => true, 
+    :url_ignore => [/feed.xml/, "#", /teams.fhcrc.org/, 
+                    /toolbox.fhcrc.org/, /galaxy.fredhutch.org/,
+                    /rstudio.fhcrc.org/, /jupyterhub.fhcrc.org/,
+                    /aspera.fhcrc.org/, /mydb.fredhutch.org/,
+                    /translationalgenomics.fredhutch.org/,
+                    /lists.fhcrc.org/, /slack.com/,
+                    /ontology.fredhutch.org/, /biocontainers.pro/,
+                    /hutchbase.fhcrc.org/, /batch-dashboard.fhcrc.org/],
+      :typhoeus => {:connecttimeout => 60, :timeout => 120}}
+  HTMLProofer.check_directory("./_site", options).run
+end
+
+task :testlocal do
+  sh "bundle exec jekyll build"
+  options = { :assume_extension => true,
+    :empty_alt_ignore => true, 
+    # still excluding internal URLs that require authentication
+    :url_ignore => [/teams.fhcrc.org/, /feed.xml/, "#", /slack.com/,
+                    /sw2srv/]}
+  HTMLProofer.check_directory("./_site", options).run
+end


### PR DESCRIPTION
Hey @k8hertweck I went ahead and added a rakefile and gem for testing of broken links. I then ran it and came back clean after running over 17 files and 42 links. I came across that for the [SciWiki](https://github.com/FredHutch/wiki/blob/master/README.md#checking-for-broken-links) and saw they were using it to run [HTMLProofer](https://github.com/gjtorikian/html-proofer). If you're cool with it feel free to merge.